### PR TITLE
Allow empty phone numbers to be considered valid

### DIFF
--- a/dist/ng-valid-phone.js
+++ b/dist/ng-valid-phone.js
@@ -89,6 +89,10 @@
                 };
 
                 modelCtrl.$validators.invalidPhone = function(modelValue, viewValue) {
+                    if (modelCtrl.$isEmpty(modelValue)) {
+                      return true;
+                    }
+
                     return IsPhoneValid(modelValue);
                 };
             }


### PR DESCRIPTION
Needed so that accept an empty field and have it be considered valid.
This is per Angular documentation/examples under form custom validation.
If the required attribute is set then the form will require the field
to be populated.